### PR TITLE
Fixed missing template_dir method

### DIFF
--- a/molecule_azure/driver.py
+++ b/molecule_azure/driver.py
@@ -141,7 +141,7 @@ class Azure(Driver):
         # FIXME(decentral1se): Implement sanity checks
         pass
 
-    def _get_template_path(self):
+    def template_dir(self):
         """ Return path to its own cookiecutterm templates. It is used by init
         command in order to figure out where to load the templates from.
         """


### PR DESCRIPTION
Override original template_dir() from base in order to get the correct
path to driver templates.