### PR TITLE
Use azure dependencies declared by Ansible

### DIFF
--- a/molecule_azure/driver.py
+++ b/molecule_azure/driver.py
@@ -45,7 +45,7 @@ class Azure(Driver):
 
     .. code-block:: bash
 
-        $ pip install 'ansible[azure]'
+        $ pip install 'molecule-azure'
 
     Change the options passed to the ssh client.
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -63,7 +63,8 @@ setup_requires =
 
 # These are required in actual runtime:
 install_requires =
-    azure
+    # https://github.com/ansible/ansible/blob/devel/packaging/requirements/requirements-azure.txt
+    ansible[azure]
     molecule >= 3.0a3
     pyyaml >= 5.1, < 6
 


### PR DESCRIPTION
Instead of installing azure meta-package which can cause failures or
conflicts, we rely on Ansible 'azure' extra to install required
azure libraries.