### PR TITLE
Made dependencies compatible with newer molecule

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,9 +1,6 @@
 [aliases]
 dists = clean --all sdist bdist_wheel
 
-[bdist_wheel]
-universal = 1
-
 [metadata]
 name = molecule-azure
 url = https://github.com/ansible-community/molecule-azure
@@ -26,6 +23,7 @@ license = MIT
 license_file = LICENSE
 classifiers =
     Development Status :: 5 - Production/Stable
+
     Environment :: Console
     Framework :: Pytest
     Intended Audience :: Developers
@@ -35,10 +33,10 @@ classifiers =
     Natural Language :: English
     Operating System :: OS Independent
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
 
     Topic :: System :: Systems Administration
     Topic :: Utilities
@@ -65,26 +63,12 @@ setup_requires =
 
 # These are required in actual runtime:
 install_requires =
-    # https://github.com/ansible/ansible/blob/devel/packaging/requirements/requirements-azure.txt
-    ansible >= 2.10
-    molecule >= 3.0.2
-    pyyaml >= 5.1, < 6
+    # molecule plugins are not allowed to mention Ansible as a direct dependency
+    molecule >= 3.1.3
 
 [options.extras_require]
 test =
-    ansi2html  # soft-dependency of pytest-html
-    coverage>=4.4, < 5  # drop '<5' when we drop py27 as we cannot mix them
-    flake8>=3.6.0, < 4
-
-    mock>=3.0.5, < 4
-    pytest>=4.6.3, < 5
-    pytest-cov>=2.7.1, < 3
-    pytest-helpers-namespace>=2019.1.8, < 2020
-    pytest-html
-    pytest-mock>=1.10.4, < 2
-    pytest-verbose-parametrize>=1.7.0, < 2
-    pytest-xdist>=1.29.0, < 2
-    pytest-dependency
+    molecule[ansible,test]
 
 [options.entry_points]
 molecule.driver =


### PR DESCRIPTION
Molecule requires drivers not to mention Ansible as a dependency in order to keep itself decoupled from Ansible.

The still can check Ansible version at runtime but not to use python to talk with it.